### PR TITLE
update amq-protocol to 0.15.0

### DIFF
--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -15,7 +15,7 @@ build = "build.rs"
 log = "^0.3"
 nom = "^2.2"
 cookie-factory = "^0.2"
-amq-protocol = "^0.11"
+amq-protocol = "^0.15"
 clippy = {version = "^0.0.119", optional = true}
 
 [dependencies.sasl]
@@ -23,7 +23,7 @@ version= "^0.4"
 default-features = false
 
 [build-dependencies]
-amq-protocol = "^0.11"
+amq-protocol = "^0.15"
 
 [dev-dependencies]
 env_logger = "^0.4"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -19,7 +19,7 @@ tokio-io = "^0.1"
 tokio-timer = "^0.1"
 lapin-async = "^0.5"
 cookie-factory = "^0.2"
-amq-protocol = "^0.11"
+amq-protocol = "^0.15"
 
 [dev-dependencies]
 nom = "^2.1"


### PR DESCRIPTION
It doesn't change much but it follows rabbitmq choices regarding types:

https://www.rabbitmq.com/amqp-0-9-1-errata.html