### PR TITLE
Frames handling simplifications

### DIFF
--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -174,9 +174,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("exchange_declare request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           trace!("exchange_declare returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -208,9 +206,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("queue_declare request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           trace!("queue_declare returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -239,9 +235,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("queue_bind request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           trace!("queue_bind returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -266,9 +260,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("confirm select request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           wait_for_answer(cl_transport, request_id)
         },
@@ -298,11 +290,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(delivery_tag) => {
-          transport.send_frames();
+          transport.send_and_handle_frames();
           transport.conn.send_content_frames(self.id, 60, payload, properties);
-          transport.send_frames();
+          transport.send_and_handle_frames();
 
-          transport.handle_frames();
           if transport.conn.channels.get_mut(&self.id).map(|c| c.confirm).unwrap_or(false) {
             wait_for_basic_publish_confirm(cl_transport, delivery_tag, self.id)
           } else {
@@ -334,9 +325,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer")))
         ),
         Ok(request_id) => {
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           let consumer = Consumer {
             transport:    cl_transport.clone(),
@@ -368,8 +357,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(_) => {
-          transport.send_frames();
-          transport.handle_frames();
+          transport.send_and_handle_frames();
           Box::new(future::ok(()))
         },
       }
@@ -389,8 +377,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(_) => {
-          transport.send_frames();
-          transport.handle_frames();
+          transport.send_and_handle_frames();
           Box::new(future::ok(()))
         },
       }
@@ -411,8 +398,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(request_id) => {
-          transport.send_frames();
-          transport.handle_frames();
+          transport.send_and_handle_frames();
           wait_for_basic_get_answer(cl_transport, request_id, self.id, queue)
         },
       }
@@ -437,9 +423,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("purge request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           trace!("purge returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -472,9 +456,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("delete request id: {}", request_id);
-          transport.send_frames();
-
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           trace!("delete returning closure");
           wait_for_answer(cl_transport, request_id)

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -509,8 +509,7 @@ pub fn wait_for_basic_get_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc
       if let Some(message) = transport.conn.next_get_message(channel_id, &queue) {
         Ok(Async::Ready(message))
       } else {
-        transport.upstream.poll();
-        transport.heartbeat.poll();
+        transport.poll_children();
         trace!("basic get[{}-{}] not ready", channel_id, queue);
         Ok(Async::NotReady)
       }
@@ -543,7 +542,7 @@ pub fn wait_for_basic_publish_confirm<T: AsyncRead+AsyncWrite+'static>(transport
       if acked_opt.is_some() {
         return Ok(Async::Ready(acked_opt));
       } else {
-        tr.upstream.poll();
+        tr.poll_children();
         return Ok(Async::NotReady);
       }
     } else {

--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -68,8 +68,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Client<T> {
         ),
         Ok(request_id) => {
           trace!("request id: {}", request_id);
-          transport.send_frames();
-          transport.handle_frames();
+          transport.send_and_handle_frames();
 
           //FIXME: very afterwards that the state is Connected and not error
           Box::new(wait_for_answer(channel_transport.clone(), request_id).map(move |_| {

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -25,13 +25,11 @@ impl<T: AsyncRead+AsyncWrite+'static> Stream for Consumer<T> {
       transport.handle_frames();
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
-        transport.upstream.poll();
-        transport.heartbeat.poll();
+        transport.poll_children();
         //debug!("consumer[{}] ready", self.consumer_tag);
         Ok(Async::Ready(Some(message)))
       } else {
-        transport.upstream.poll();
-        transport.heartbeat.poll();
+        transport.poll_children();
         trace!("consumer[{}] not ready", self.consumer_tag);
         Ok(Async::NotReady)
       }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -140,6 +140,11 @@ impl<T> AMQPTransport<T>
     Box::new(connector)
   }
 
+  pub fn send_and_handle_frames(&mut self) {
+    self.send_frames();
+    self.handle_frames();
+  }
+
   pub fn send_frames(&mut self) {
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {


### PR DESCRIPTION
Ensure we always handle_frames after send_frames by adding send_and_handle_frames.
Add a helper to poll both upstream and heartbeat.
Use send_frames in all the places where we do similar actions.