### PR TITLE
Poll improvements

### DIFF
--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -509,7 +509,7 @@ pub fn wait_for_basic_get_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc
       if let Some(message) = transport.conn.next_get_message(channel_id, &queue) {
         Ok(Async::Ready(message))
       } else {
-        transport.poll_children();
+        transport.poll();
         trace!("basic get[{}-{}] not ready", channel_id, queue);
         Ok(Async::NotReady)
       }
@@ -542,7 +542,7 @@ pub fn wait_for_basic_publish_confirm<T: AsyncRead+AsyncWrite+'static>(transport
       if acked_opt.is_some() {
         return Ok(Async::Ready(acked_opt));
       } else {
-        tr.poll_children();
+        tr.poll();
         return Ok(Async::NotReady);
       }
     } else {

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -25,11 +25,11 @@ impl<T: AsyncRead+AsyncWrite+'static> Stream for Consumer<T> {
       transport.handle_frames();
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
-        transport.poll_children();
+        transport.poll();
         //debug!("consumer[{}] ready", self.consumer_tag);
         Ok(Async::Ready(Some(message)))
       } else {
-        transport.poll_children();
+        transport.poll();
         trace!("consumer[{}] not ready", self.consumer_tag);
         Ok(Async::NotReady)
       }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -137,6 +137,14 @@ impl<T> AMQPTransport<T>
     Box::new(connector)
   }
 
+  fn poll_heartbeat(&mut self) {
+    if let Ok(Async::Ready(_)) = self.heartbeat.poll() {
+      debug!("Heartbeat");
+      self.start_send(Frame::Heartbeat(0));
+      self.poll_complete();
+    }
+  }
+
   pub fn poll_children(&mut self) {
     self.heartbeat.poll();
     let value = match self.upstream.poll() {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -215,8 +215,7 @@ impl<T> Future for AMQPTransportConnector<T>
     let mut transport = self.transport.take().unwrap();
 
     //we might have received a frame before here
-    transport.handle_frames();
-    transport.send_frames();
+    transport.send_and_handle_frames();
 
     debug!("conn state: {:?}", transport.conn.state);
     if transport.conn.state == ConnectionState::Connected {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -172,29 +172,7 @@ impl<T> AMQPTransport<T>
 
   pub fn poll_children(&mut self) {
     self.poll_heartbeat();
-    let value = match self.upstream.poll() {
-      Ok(Async::Ready(t)) => t,
-      Ok(Async::NotReady) => {
-        trace!("NotReady");
-        return;
-      },
-      Err(e) => {
-        error!("upstream poll got error: {:?}", e);
-        return;
-      },
-    };
-
-    match value {
-      Some(frame) => {
-        trace!("got frame: {:?}", frame);
-        self.conn.handle_frame(frame);
-        self.send_frames();
-        self.upstream.poll_complete();
-      },
-      e => {
-        error!("did not get a frame? -> {:?}", e);
-      }
-    }
+    self.poll_upstream();
   }
 
   pub fn send_and_handle_frames(&mut self) {


### PR DESCRIPTION
Followup to 9dd1e5165b92338074adfde39b52322dbcad6f1a

Use poll_children everywhere.
poll_children does poll_heartbeat which checks the return of heartbeat.poll, then poll_upstream and then tells us if poll_upstream got a frame, an error, or nothing.

With this, the only calls to upstream.poll and heartbeat.poll are respectively from poll_heartbeat and poll_upstream, both handle correctly the returned value to emit an Heartbeat frame or to feed the frame we received to lapin-async. The only call to poll_upstream and poll_heartbeat are from poll_children to ensure we always poll both.

As poll() is now just a call to poll_children(), kill poll_children by inlining it into poll()