### PR TITLE
Misc cleanups

### DIFF
--- a/async/examples/connection.rs
+++ b/async/examples/connection.rs
@@ -14,7 +14,7 @@ use lapin::generated::basic;
 fn main() {
       env_logger::init().unwrap();
       let mut stream = TcpStream::connect("127.0.0.1:5672").unwrap();
-      stream.set_nonblocking(true);
+      stream.set_nonblocking(true).unwrap();
 
       let capacity = 8192;
       let mut send_buffer    = Buffer::with_capacity(capacity as usize);

--- a/async/src/api.rs
+++ b/async/src/api.rs
@@ -799,7 +799,7 @@ impl Connection {
 
     pub fn receive_exchange_declare_ok(&mut self,
                                        _channel_id: u16,
-                                       method: exchange::DeclareOk)
+                                       _: exchange::DeclareOk)
                                        -> Result<(), Error> {
 
         if !self.channels.contains_key(&_channel_id) {
@@ -1548,7 +1548,7 @@ impl Connection {
         }
 
         match self.get_next_answer(_channel_id) {
-          Some(Answer::AwaitingBasicGetAnswer(request_id, queue_name)) => {
+          Some(Answer::AwaitingBasicGetAnswer(request_id, _)) => {
             self.finished_get_reqs.insert(request_id, false);
             Ok(())
           },
@@ -1881,7 +1881,7 @@ impl Connection {
 
     pub fn receive_confirm_select_ok(&mut self,
                                      _channel_id: u16,
-                                     method: confirm::SelectOk)
+                                     _: confirm::SelectOk)
                                      -> Result<(), Error> {
 
         if !self.channels.contains_key(&_channel_id) {
@@ -1942,7 +1942,7 @@ impl Connection {
 
             Ok(())
           },
-          m => {
+          _ => {
             self.set_channel_state(_channel_id, ChannelState::Error);
             return Err(Error::UnexpectedAnswer);
           }

--- a/async/src/buffer.rs
+++ b/async/src/buffer.rs
@@ -230,7 +230,7 @@ mod tests {
   #[test]
   fn delete() {
     let mut b = Buffer::with_capacity(10);
-    let res = b.write(&b"abcdefgh"[..]);
+    b.write(&b"abcdefgh"[..]).expect("Failed to write to buffer");
     assert_eq!(b.available_data(), 8);
     assert_eq!(b.available_space(), 2);
 
@@ -246,7 +246,7 @@ mod tests {
   #[test]
   fn replace() {
     let mut b = Buffer::with_capacity(10);
-    let res = b.write(&b"abcdefgh"[..]);
+    b.write(&b"abcdefgh"[..]).expect("Failed to write to buffer");
     assert_eq!(b.available_data(), 8);
     assert_eq!(b.available_space(), 2);
 

--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -185,13 +185,6 @@ impl Connection {
   }
 
   #[doc(hidden)]
-  fn check_next_answer(&self, channel_id: u16, answer: Answer) -> bool {
-    self.channels
-          .get(&channel_id)
-          .map(|c| c.awaiting.front() == Some(&answer)).unwrap_or(false)
-  }
-
-  #[doc(hidden)]
   pub fn get_next_answer(&mut self, channel_id: u16) -> Option<Answer> {
     self.channels
           .get_mut(&channel_id)

--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -384,7 +384,7 @@ impl Connection {
       },
       ConnectionState::Connecting(connecting_state) => {
         match connecting_state {
-          ConnectingState::Initial | ConnectingState::Error => {
+          ConnectingState::Initial => {
             self.state = ConnectionState::Error
           },
           ConnectingState::SentProtocolHeader => {

--- a/async/tests/connection.rs
+++ b/async/tests/connection.rs
@@ -13,7 +13,7 @@ use lapin::generated::basic;
 #[test]
 fn connection() {
       let mut stream = TcpStream::connect("127.0.0.1:5672").unwrap();
-      stream.set_nonblocking(true);
+      stream.set_nonblocking(true).unwrap();
 
       let capacity = 8192;
       let mut send_buffer    = Buffer::with_capacity(capacity as usize);

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -1,5 +1,5 @@
 use std::io::{self,Error,ErrorKind};
-use futures::{Async,Future,future,Stream};
+use futures::{Async,Future,future};
 use amq_protocol::types::*;
 use tokio_io::{AsyncRead,AsyncWrite};
 use std::sync::{Arc,Mutex};
@@ -529,7 +529,7 @@ pub fn wait_for_basic_get_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc
       if let Some(message) = transport.conn.next_get_message(channel_id, &queue) {
         Ok(Async::Ready(message))
       } else {
-        transport.poll();
+        transport.handle_frames();
         trace!("basic get[{}-{}] not ready", channel_id, queue);
         Ok(Async::NotReady)
       }
@@ -562,7 +562,7 @@ pub fn wait_for_basic_publish_confirm<T: AsyncRead+AsyncWrite+'static>(transport
       if acked_opt.is_some() {
         return Ok(Async::Ready(acked_opt));
       } else {
-        tr.poll();
+        tr.handle_frames();
         return Ok(Async::NotReady);
       }
     } else {

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -322,7 +322,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
       match transport.conn.basic_consume(self.id, options.ticket, queue.to_string(), consumer_tag.to_string(),
         options.no_local, options.no_ack, options.exclusive, options.no_wait, FieldTable::new()) {
         Err(e) => Box::new(
-          future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer")))
+          future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer: {:?}", e)))
         ),
         Ok(request_id) => {
           transport.send_and_handle_frames();

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -25,11 +25,11 @@ impl<T: AsyncRead+AsyncWrite+'static> Stream for Consumer<T> {
       transport.handle_frames();
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
-        transport.poll();
+        transport.handle_frames();
         //debug!("consumer[{}] ready", self.consumer_tag);
         Ok(Async::Ready(Some(message)))
       } else {
-        transport.poll();
+        transport.handle_frames();
         trace!("consumer[{}] not ready", self.consumer_tag);
         Ok(Async::NotReady)
       }

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -130,15 +130,15 @@
 //! ```
 //!
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate futures;
 extern crate amq_protocol;
-extern crate nom;
+extern crate cookie_factory;
 extern crate bytes;
+extern crate futures;
+extern crate lapin_async;
+#[macro_use] extern crate log;
+extern crate nom;
 extern crate tokio_io;
 extern crate tokio_timer;
-extern crate lapin_async;
-extern crate cookie_factory;
 
 pub mod client;
 pub mod transport;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Publishing a message
 //!
-//! ```rust
+//! ```rust,no_run
 //! #[macro_use] extern crate log;
 //! extern crate lapin_futures as lapin;
 //! extern crate amq_protocol;
@@ -68,7 +68,7 @@
 //!
 //! ## Creating a consumer
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! #[macro_use] extern crate log;
 //! extern crate lapin_futures as lapin;
 //! extern crate amq_protocol;

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -124,7 +124,6 @@ impl<T> AMQPTransport<T>
     };
 
     t.send_and_handle_frames();
-    t.poll();
 
     let mut connector = AMQPTransportConnector {
       transport: Some(t)
@@ -226,7 +225,7 @@ impl<T> Future for AMQPTransportConnector<T>
             Async::Ready(transport)
           } else {
             // Upstream had frames but we're not yet connected, continue polling
-            transport.poll();
+            transport.handle_frames();
             self.transport = Some(transport);
             Async::NotReady
           }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -185,7 +185,6 @@ impl<T> AMQPTransport<T>
         break;
       }
     }
-    self.poll_complete();
   }
 
   fn send_frame(&mut self, frame: Frame) -> Poll<(), io::Error> {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -161,7 +161,7 @@ impl<T> AMQPTransport<T>
       trace!("upstream poll gave frame: {:?}", frame);
       self.conn.handle_frame(frame);
       self.send_frames();
-      self.upstream.poll_complete();
+      self.poll_complete();
       Ok(Async::Ready(Some(())))
     } else {
       error!("upstream poll gave Ready(None)");
@@ -178,9 +178,9 @@ impl<T> AMQPTransport<T>
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {
       self.upstream.start_send(f);
-      self.upstream.poll_complete();
+      self.poll_complete();
     }
-    //self.upstream.poll_complete();
+    //self.poll_complete();
   }
 
   pub fn handle_frames(&mut self) {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -130,7 +130,7 @@ impl<T> AMQPTransport<T>
     };
 
     trace!("pre-poll");
-    connector.poll();
+    connector.poll().ok();
     trace!("post-poll");
 
     Box::new(connector)
@@ -138,9 +138,10 @@ impl<T> AMQPTransport<T>
 
   fn poll_heartbeat(&mut self) {
     if let Ok(Async::Ready(_)) = self.heartbeat.poll() {
-      debug!("Heartbeat");
-      self.start_send(Frame::Heartbeat(0));
-      self.poll_complete();
+      trace!("Sending heartbeat");
+      if let Err(e) = self.send_frame(Frame::Heartbeat(0)) {
+        debug!("Failed to send heartbeat: {:?}", e);
+      }
     }
   }
 
@@ -161,7 +162,6 @@ impl<T> AMQPTransport<T>
       trace!("upstream poll gave frame: {:?}", frame);
       self.conn.handle_frame(frame);
       self.send_frames();
-      self.poll_complete();
       Ok(Async::Ready(Some(())))
     } else {
       error!("upstream poll gave Ready(None)");
@@ -177,10 +177,13 @@ impl<T> AMQPTransport<T>
   pub fn send_frames(&mut self) {
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {
-      self.upstream.start_send(f);
-      self.poll_complete();
+      self.send_frame(f);
     }
-    //self.poll_complete();
+    self.poll_complete();
+  }
+
+  fn send_frame(&mut self, frame: Frame) -> Poll<(), io::Error> {
+      self.start_send(frame).and_then(|_| self.poll_complete())
   }
 
   pub fn handle_frames(&mut self) {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -140,7 +140,7 @@ impl<T> AMQPTransport<T>
     if let Ok(Async::Ready(_)) = self.heartbeat.poll() {
       trace!("Sending heartbeat");
       if let Err(e) = self.send_frame(Frame::Heartbeat(0)) {
-        debug!("Failed to send heartbeat: {:?}", e);
+        error!("Failed to send heartbeat: {:?}", e);
       }
     }
   }
@@ -177,7 +177,10 @@ impl<T> AMQPTransport<T>
   pub fn send_frames(&mut self) {
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {
-      self.send_frame(f);
+      if let Err(e) = self.send_frame(f) {
+        error!("Failed to send frame: {:?}", e);
+        break;
+      }
     }
     self.poll_complete();
   }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -98,8 +98,8 @@ impl Encoder for AMQPCodec {
 
 /// Wrappers over a `Framed` stream using `AMQPCodec` and lapin-async's `Connection`
 pub struct AMQPTransport<T> {
-  pub upstream: Framed<T,AMQPCodec>,
-  pub heartbeat: Interval,
+  upstream: Framed<T,AMQPCodec>,
+  heartbeat: Interval,
   pub conn: Connection,
 }
 


### PR DESCRIPTION
Prefer using self.start_send and self.poll_complete to self.upstream.start_send and self.upstream.poll_complete
Use handle_frames instead of poll when we don't care about the return value of poll.
Don't poll just after handle_frames
Split send_frame and use it where appropriate
Log when hitting some errors

This has the benefit of silencing all the warnings from the futures and async crates.