### PR TITLE
Poll return value handling

### DIFF
--- a/async/examples/connection.rs
+++ b/async/examples/connection.rs
@@ -14,7 +14,7 @@ use lapin::generated::basic;
 fn main() {
       env_logger::init().unwrap();
       let mut stream = TcpStream::connect("127.0.0.1:5672").unwrap();
-      stream.set_nonblocking(true);
+      stream.set_nonblocking(true).unwrap();
 
       let capacity = 8192;
       let mut send_buffer    = Buffer::with_capacity(capacity as usize);

--- a/async/src/api.rs
+++ b/async/src/api.rs
@@ -799,7 +799,7 @@ impl Connection {
 
     pub fn receive_exchange_declare_ok(&mut self,
                                        _channel_id: u16,
-                                       method: exchange::DeclareOk)
+                                       _: exchange::DeclareOk)
                                        -> Result<(), Error> {
 
         if !self.channels.contains_key(&_channel_id) {
@@ -1548,7 +1548,7 @@ impl Connection {
         }
 
         match self.get_next_answer(_channel_id) {
-          Some(Answer::AwaitingBasicGetAnswer(request_id, queue_name)) => {
+          Some(Answer::AwaitingBasicGetAnswer(request_id, _)) => {
             self.finished_get_reqs.insert(request_id, false);
             Ok(())
           },
@@ -1881,7 +1881,7 @@ impl Connection {
 
     pub fn receive_confirm_select_ok(&mut self,
                                      _channel_id: u16,
-                                     method: confirm::SelectOk)
+                                     _: confirm::SelectOk)
                                      -> Result<(), Error> {
 
         if !self.channels.contains_key(&_channel_id) {
@@ -1942,7 +1942,7 @@ impl Connection {
 
             Ok(())
           },
-          m => {
+          _ => {
             self.set_channel_state(_channel_id, ChannelState::Error);
             return Err(Error::UnexpectedAnswer);
           }

--- a/async/src/buffer.rs
+++ b/async/src/buffer.rs
@@ -230,7 +230,7 @@ mod tests {
   #[test]
   fn delete() {
     let mut b = Buffer::with_capacity(10);
-    let res = b.write(&b"abcdefgh"[..]);
+    b.write(&b"abcdefgh"[..]).expect("Failed to write to buffer");
     assert_eq!(b.available_data(), 8);
     assert_eq!(b.available_space(), 2);
 
@@ -246,7 +246,7 @@ mod tests {
   #[test]
   fn replace() {
     let mut b = Buffer::with_capacity(10);
-    let res = b.write(&b"abcdefgh"[..]);
+    b.write(&b"abcdefgh"[..]).expect("Failed to write to buffer");
     assert_eq!(b.available_data(), 8);
     assert_eq!(b.available_space(), 2);
 

--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -185,13 +185,6 @@ impl Connection {
   }
 
   #[doc(hidden)]
-  fn check_next_answer(&self, channel_id: u16, answer: Answer) -> bool {
-    self.channels
-          .get(&channel_id)
-          .map(|c| c.awaiting.front() == Some(&answer)).unwrap_or(false)
-  }
-
-  #[doc(hidden)]
   pub fn get_next_answer(&mut self, channel_id: u16) -> Option<Answer> {
     self.channels
           .get_mut(&channel_id)

--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -384,7 +384,7 @@ impl Connection {
       },
       ConnectionState::Connecting(connecting_state) => {
         match connecting_state {
-          ConnectingState::Initial | ConnectingState::Error => {
+          ConnectingState::Initial => {
             self.state = ConnectionState::Error
           },
           ConnectingState::SentProtocolHeader => {

--- a/async/tests/connection.rs
+++ b/async/tests/connection.rs
@@ -13,7 +13,7 @@ use lapin::generated::basic;
 #[test]
 fn connection() {
       let mut stream = TcpStream::connect("127.0.0.1:5672").unwrap();
-      stream.set_nonblocking(true);
+      stream.set_nonblocking(true).unwrap();
 
       let capacity = 8192;
       let mut send_buffer    = Buffer::with_capacity(capacity as usize);

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -174,7 +174,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("exchange_declare request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           trace!("exchange_declare returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -206,7 +209,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("queue_declare request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           trace!("queue_declare returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -235,7 +241,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("queue_bind request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           trace!("queue_bind returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -260,7 +269,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("confirm select request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           wait_for_answer(cl_transport, request_id)
         },
@@ -290,9 +302,15 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(delivery_tag) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
           transport.conn.send_content_frames(self.id, 60, payload, properties);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           if transport.conn.channels.get_mut(&self.id).map(|c| c.confirm).unwrap_or(false) {
             wait_for_basic_publish_confirm(cl_transport, delivery_tag, self.id)
@@ -325,7 +343,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer: {:?}", e)))
         ),
         Ok(request_id) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           let consumer = Consumer {
             transport:    cl_transport.clone(),
@@ -357,7 +378,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(_) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
           Box::new(future::ok(()))
         },
       }
@@ -377,7 +401,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(_) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
           Box::new(future::ok(()))
         },
       }
@@ -398,7 +425,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(request_id) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
           wait_for_basic_get_answer(cl_transport, request_id, self.id, queue)
         },
       }
@@ -423,7 +453,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("purge request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           trace!("purge returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -456,7 +489,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         ),
         Ok(request_id) => {
           trace!("delete request id: {}", request_id);
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
 
           trace!("delete returning closure");
           wait_for_answer(cl_transport, request_id)
@@ -478,7 +514,10 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::Other, format!("could not close channel: {:?}", e)))
         ),
         Ok(_) => {
-          transport.send_and_handle_frames();
+          if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+          }
           Box::new(future::ok(()))
         },
       }
@@ -500,10 +539,10 @@ pub fn wait_for_basic_get_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc
 
   let request_future = future::poll_fn(move || {
     let result = if let Ok(mut tr) = transport.try_lock() {
-      tr.handle_frames();
+      tr.handle_frames()?;
       match tr.conn.finished_get_result(request_id) {
         None =>  {
-          tr.handle_frames();
+          tr.handle_frames()?;
           if let Some(res) = tr.conn.finished_get_result(request_id) {
             res
           } else {
@@ -525,11 +564,11 @@ pub fn wait_for_basic_get_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc
 
   let receive_future = future::poll_fn(move || {
     if let Ok(mut transport) = receive_transport.try_lock() {
-      transport.handle_frames();
+      transport.handle_frames()?;
       if let Some(message) = transport.conn.next_get_message(channel_id, &queue) {
         Ok(Async::Ready(message))
       } else {
-        transport.poll();
+        transport.poll()?;
         trace!("basic get[{}-{}] not ready", channel_id, queue);
         Ok(Async::NotReady)
       }
@@ -547,7 +586,7 @@ pub fn wait_for_basic_publish_confirm<T: AsyncRead+AsyncWrite+'static>(transport
 
   Box::new(future::poll_fn(move || {
     if let Ok(mut tr) = transport.try_lock() {
-      tr.handle_frames();
+      tr.handle_frames()?;
       let acked_opt = tr.conn.channels.get_mut(&channel_id).map(|c| {
         if c.acked.remove(&delivery_tag) {
           Some(true)
@@ -562,7 +601,7 @@ pub fn wait_for_basic_publish_confirm<T: AsyncRead+AsyncWrite+'static>(transport
       if acked_opt.is_some() {
         return Ok(Async::Ready(acked_opt));
       } else {
-        tr.poll();
+        tr.poll()?;
         return Ok(Async::NotReady);
       }
     } else {

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -322,7 +322,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
       match transport.conn.basic_consume(self.id, options.ticket, queue.to_string(), consumer_tag.to_string(),
         options.no_local, options.no_ack, options.exclusive, options.no_wait, FieldTable::new()) {
         Err(e) => Box::new(
-          future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer")))
+          future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer: {:?}", e)))
         ),
         Ok(request_id) => {
           transport.send_and_handle_frames();

--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -107,8 +107,6 @@ pub fn wait_for_answer<T: AsyncRead+AsyncWrite+'static>(transport: Arc<Mutex<AMQ
     let connected = if let Ok(mut tr) = transport.try_lock() {
       tr.handle_frames();
       if ! tr.conn.is_finished(request_id) {
-        //retry because we might have obtained a new frame
-        tr.handle_frames();
         tr.conn.is_finished(request_id)
       } else {
         true

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -22,14 +22,14 @@ impl<T: AsyncRead+AsyncWrite+'static> Stream for Consumer<T> {
   fn poll(&mut self) -> Poll<Option<Message>, io::Error> {
     //trace!("consumer[{}] poll", self.consumer_tag);
     if let Ok(mut transport) = self.transport.try_lock() {
-      transport.handle_frames();
+      transport.handle_frames()?;
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
-        transport.poll();
+        transport.poll()?;
         //debug!("consumer[{}] ready", self.consumer_tag);
         Ok(Async::Ready(Some(message)))
       } else {
-        transport.poll();
+        transport.poll()?;
         trace!("consumer[{}] not ready", self.consumer_tag);
         Ok(Async::NotReady)
       }

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -130,15 +130,15 @@
 //! ```
 //!
 
-#[macro_use] extern crate log;
-#[macro_use] extern crate futures;
 extern crate amq_protocol;
-extern crate nom;
+extern crate cookie_factory;
 extern crate bytes;
+extern crate futures;
+extern crate lapin_async;
+#[macro_use] extern crate log;
+extern crate nom;
 extern crate tokio_io;
 extern crate tokio_timer;
-extern crate lapin_async;
-extern crate cookie_factory;
 
 pub mod client;
 pub mod transport;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -133,7 +133,7 @@
 extern crate amq_protocol;
 extern crate cookie_factory;
 extern crate bytes;
-extern crate futures;
+#[macro_use] extern crate futures;
 extern crate lapin_async;
 #[macro_use] extern crate log;
 extern crate nom;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Publishing a message
 //!
-//! ```rust
+//! ```rust,no_run
 //! #[macro_use] extern crate log;
 //! extern crate lapin_futures as lapin;
 //! extern crate amq_protocol;
@@ -68,7 +68,7 @@
 //!
 //! ## Creating a consumer
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! #[macro_use] extern crate log;
 //! extern crate lapin_futures as lapin;
 //! extern crate amq_protocol;

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -162,7 +162,7 @@ impl<T> AMQPTransport<T>
       trace!("upstream poll gave frame: {:?}", frame);
       self.conn.handle_frame(frame);
       self.send_frames();
-      self.upstream.poll_complete();
+      self.poll_complete();
       Ok(Async::Ready(Some(())))
     } else {
       error!("upstream poll gave Ready(None)");
@@ -179,9 +179,9 @@ impl<T> AMQPTransport<T>
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {
       self.upstream.start_send(f);
-      self.upstream.poll_complete();
+      self.poll_complete();
     }
-    //self.upstream.poll_complete();
+    //self.poll_complete();
   }
 
   pub fn handle_frames(&mut self) {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -186,7 +186,6 @@ impl<T> AMQPTransport<T>
         break;
       }
     }
-    self.poll_complete();
   }
 
   fn send_frame(&mut self, frame: Frame) -> Poll<(), io::Error> {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -127,7 +127,6 @@ impl<T> AMQPTransport<T>
     };
 
     t.send_and_handle_frames();
-    t.poll();
 
     let mut connector = AMQPTransportConnector {
       transport: Some(t)

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -141,7 +141,7 @@ impl<T> AMQPTransport<T>
     if let Ok(Async::Ready(_)) = self.heartbeat.poll() {
       trace!("Sending heartbeat");
       if let Err(e) = self.send_frame(Frame::Heartbeat(0)) {
-        debug!("Failed to send heartbeat: {:?}", e);
+        error!("Failed to send heartbeat: {:?}", e);
       }
     }
   }
@@ -178,7 +178,10 @@ impl<T> AMQPTransport<T>
   pub fn send_frames(&mut self) {
     //FIXME: find a way to use a future here
     while let Some(f) = self.conn.next_frame() {
-      self.send_frame(f);
+      if let Err(e) = self.send_frame(f) {
+        error!("Failed to send frame: {:?}", e);
+        break;
+      }
     }
     self.poll_complete();
   }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -98,8 +98,8 @@ impl Encoder for AMQPCodec {
 
 /// Wrappers over a `Framed` stream using `AMQPCodec` and lapin-async's `Connection`
 pub struct AMQPTransport<T> {
-  pub upstream: Framed<T,AMQPCodec>,
-  pub heartbeat: Interval,
+  upstream: Framed<T,AMQPCodec>,
+  heartbeat: Interval,
   pub conn: Connection,
 }
 

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -192,7 +192,13 @@ impl<T> AMQPTransport<T>
   }
 
   pub fn handle_frames(&mut self) {
-    while let Ok(Async::Ready(Some(_))) = self.poll() {}
+    for _ in 0..30 {
+      if let Ok(Async::Ready(Some(_))) = self.poll() {
+        // Do nothing
+      } else {
+        break;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Right now, we never handle errors when calling poll (or indirectly calling it through handle_frames).
Bubble up or handle the errors where appropriate.

This is based on #41 